### PR TITLE
Fix link errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,14 +65,7 @@ if(MSVC)
 endif()
 
 if(NOT MSVC) #we have auto-linking in Visual Studio
-	target_link_libraries(mysql
-		"${Boost_ATOMIC_LIBRARY}"
-		"${Boost_CHRONO_LIBRARY}"
-		"${Boost_DATE_TIME_LIBRARY}"
-		"${Boost_FILESYSTEM_LIBRARY}"
-		"${Boost_SYSTEM_LIBRARY}"
-		"${Boost_THREAD_LIBRARY}"
-	)
+	target_link_libraries(mysql ${Boost_LIBRARIES})
 endif()
 
 if(BUILD_STATIC)


### PR DESCRIPTION
The quotes around Boost_XXX_LIBRARY caused some link errors on Linux:

```
Linking CXX shared module mysql_d.so
/usr/bin/ld: cannot find -loptimized
/usr/bin/ld: cannot find -ldebug
/usr/bin/ld: cannot find -loptimized
/usr/bin/ld: cannot find -ldebug
/usr/bin/ld: cannot find -loptimized
/usr/bin/ld: cannot find -ldebug
/usr/bin/ld: cannot find -loptimized
/usr/bin/ld: cannot find -ldebug
/usr/bin/ld: cannot find -loptimized
/usr/bin/ld: cannot find -ldebug
/usr/bin/ld: cannot find -loptimized
/usr/bin/ld: cannot find -ldebug
/usr/bin/ld: cannot find -loptimized
collect2: error: ld returned 1 exit status
make[2]: *** [src/mysql_d.so] Error 1
make[1]: *** [src/CMakeFiles/mysql.dir/all] Error 2
make: *** [all] Error 2
```

CMake just literally copied the "optimized" and "debug" keybwords to the Makefile.