### PR TITLE
Fixed typo in UpdatePlayerKills(killerid)

### DIFF
--- a/example_scripts/login_system-cache.pwn
+++ b/example_scripts/login_system-cache.pwn
@@ -375,7 +375,7 @@ UpdatePlayerKills(killerid)
 	Player[killerid][Kills]++;
 	
 	new query[70];
-	mysql_format(g_SQL, query, sizeof query, "UPDATE `players` SET `kills` = %d WHERE `id` = %d LIMIT 1", Player[killerid][Deaths], Player[killerid][ID]);
+	mysql_format(g_SQL, query, sizeof query, "UPDATE `players` SET `kills` = %d WHERE `id` = %d LIMIT 1", Player[killerid][Kills], Player[killerid][ID]);
 	mysql_tquery(g_SQL, query);
 	return 1;
 }


### PR DESCRIPTION
Fixed a typo in the function UpdatePlayerKills(killerid). It was set to update a player's kills in the database to be the same as their deaths.