### PR TITLE
added runtime section

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -24,6 +24,9 @@
             }
         }
     ],
+    "runtime": {
+        "plugins": ["pBlueG/SA-MP-MySQL"]
+    },
     "contributors": [
         "AndreT",
         "DamianC",


### PR DESCRIPTION
so dependent packages know to pull the plugin binaries without needing to explicitly specify them