### PR TITLE
Totally untested sscanf utilising code...

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,8 @@ add_samp_plugin(mysql
 	mysql.hpp
 	sdk.hpp
 	types.hpp
+	sscanf.cpp
+	sscanf.hpp
 	plugin.def
 )
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "version.hpp"
 
 #include "mysql.hpp"
+#include "sscanf.hpp"
 
 
 
@@ -34,6 +35,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData)
 	}
 
 	logprintf(" >> plugin.mysql: " MYSQL_VERSION " successfully loaded.");
+	FindSscanf();
 	return true;
 }
 
@@ -63,6 +65,7 @@ PLUGIN_EXPORT void PLUGIN_CALL ProcessTick()
 
 extern "C" const AMX_NATIVE_INFO native_list[] =
 {
+	AMX_DEFINE_NATIVE(cache_get_sscanf) // MUST come first.
 	AMX_DEFINE_NATIVE(orm_create)
 	AMX_DEFINE_NATIVE(orm_destroy)
 
@@ -148,7 +151,8 @@ PLUGIN_EXPORT int PLUGIN_CALL AmxLoad(AMX *amx)
 {
 	samplog::Api::Get()->RegisterAmx(amx);
 	CCallbackManager::Get()->AddAmx(amx);
-	return amx_Register(amx, native_list, -1);
+	// Skip the first native table entry if `sscanf` isn't loaded.
+	return amx_Register(amx, native_list + (PawnSScanf ? 0 : 1), -1);
 }
 
 PLUGIN_EXPORT int PLUGIN_CALL AmxUnload(AMX *amx)

--- a/src/misc.hpp
+++ b/src/misc.hpp
@@ -13,6 +13,8 @@ using std::string;
 namespace qi = boost::spirit::qi;
 namespace karma = boost::spirit::karma;
 
+typedef cell (PAWN_NATIVE_API *sscanf_t)(AMX * amx, char * string, char * format, cell * params, int paramCount, char * file, int line);
+extern sscanf_t PawnSScanf;
 
 template<typename T>
 bool ConvertStrToData(const string &src, T &dest)

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -92,4 +92,7 @@ namespace Native
 
 	AMX_DECLARE_NATIVE(cache_get_query_exec_time);
 	AMX_DECLARE_NATIVE(cache_get_query_string);
+	
+	// sscanf natives
+	AMX_DECLARE_NATIVE(cache_get_sscanf);
 };

--- a/src/sscanf.cpp
+++ b/src/sscanf.cpp
@@ -14,107 +14,84 @@
 sscanf_t PawnSScanf;
 extern logprintf_t logprintf;
 
+struct lmap
+{
+	void
+		* base_address;
+	char
+		* path;
+	void
+		* unk_1;
+	struct lmap
+		* next,
+		* prev;
+};
+
+bool FindSscanf()
+{
+	// Find if sscanf is already loaded:
+	logprintf(" >> plugin.mysql: finding sscanf...");
 #ifdef _WIN32
-	bool FindSscanf()
+	HANDLE server = GetCurrentProcess();
+	HMODULE hMods[1024];
+	DWORD cbNeeded;
+	HMODULE dll = 0;
+	if (EnumProcessModules(server, hMods, sizeof(hMods), &cbNeeded))
 	{
-		// Find if sscanf is already loaded:
-		logprintf(" >> plugin.mysql: finding sscanf...");
-		HANDLE server = GetCurrentProcess();
-		HMODULE hMods[1024];
-		DWORD cbNeeded;
-		HMODULE dll = 0;
-		if (EnumProcessModules(server, hMods, sizeof(hMods), &cbNeeded))
+		for (unsigned int i = 0; i < (cbNeeded / sizeof(HMODULE)); i++)
 		{
-			for (unsigned int i = 0; i < (cbNeeded / sizeof(HMODULE)); i++)
+			TCHAR szModName[MAX_PATH];
+			if (GetModuleFileNameEx(server, hMods[i], szModName, sizeof(szModName) / sizeof(TCHAR)))
 			{
-				TCHAR szModName[MAX_PATH];
-				if (GetModuleFileNameEx(server, hMods[i], szModName, sizeof(szModName) / sizeof(TCHAR)))
+				int len = strlen(szModName);
+				if (len >= 11 && strcmp("\\sscanf.DLL", szModName + len - 11) == 0)
 				{
-					int len = strlen(szModName);
-					if (len >= 11 && strcmp("\\sscanf.DLL", szModName + len - 11) == 0)
-					{
-						dll = hMods[i];
-						break;
-					}
+					dll = hMods[i];
+					break;
 				}
 			}
-		}
-
-		if (dll)
-		{
-			PawnSScanf = (sscanf_t)GetProcAddress(dll, "PawnSScanf");
-			if (PawnSScanf)
-			{
-				logprintf(" >> plugin.mysql: succeeded: %p.\n", PawnSScanf);
-				return true;
-			}
-			else
-			{
-				logprintf(" >> plugin.mysql: failed, ensure the plugin version is at least 2.10.3.\n");
-				logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
-				return false;
-			}
-		}
-		else
-		{
-			logprintf(" >> plugin.mysql: failed, ensure the sscanf plugin is loaded first.\n");
-			logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
-			return false;
 		}
 	}
 #else
 	struct lmap
-	{
-		void
-			* base_address;
-		char
-			* path;
-		void
-			* unk_1;
-		struct lmap
-			* next,
-			* prev;
-	};
+		* pl = (struct lmap *)dlopen(NULL, RTLD_NOW),
+		* dll = 0;
 
-	bool FindSscanf()
+	while (pl)
 	{
-		// Find if sscanf is already loaded:
-		logprintf(" >> plugin.mysql: finding sscanf...");
-		struct lmap
-			* pl = (struct lmap *)dlopen(NULL, RTLD_NOW),
-			* dll = 0;
-
-		while (pl)
+		if (strcmp("plugins/sscanf.so", pl->path) == 0)
 		{
-			if (strcmp("plugins/sscanf.so", pl->path) == 0)
-			{
-				dll = pl;
-				break;
-			}
-			pl = pl->next;
+			dll = pl;
+			break;
 		}
+		pl = pl->next;
+	}
+#endif
 
-		if (dll)
+	if (dll)
+	{
+#ifdef _WIN32
+		PawnSScanf = (sscanf_t)GetProcAddress(dll, "PawnSScanf");
+#else
+		*(void **)(&PawnSScanf) = dlsym(dll, "PawnSScanf");
+#endif
+		if (PawnSScanf)
 		{
-			*(void **)(&PawnSScanf) = dlsym(dll, "PawnSScanf");
-			if (PawnSScanf)
-			{
-				logprintf(" >> plugin.mysql: succeeded: %p.\n", PawnSScanf);
-				return true;
-			}
-			else
-			{
-				logprintf(" >> plugin.mysql: failed, ensure the plugin version is at least 2.10.3.\n");
-				logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
-				return false;
-			}
+			logprintf(" >> plugin.mysql: succeeded: %p.\n", PawnSScanf);
+			return true;
 		}
 		else
 		{
-			logprintf(" >> plugin.mysql: failed, ensure the sscanf plugin is loaded first.\n");
+			logprintf(" >> plugin.mysql: failed, ensure the plugin version is at least 2.10.3.\n");
 			logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
 			return false;
 		}
 	}
-#endif
+	else
+	{
+		logprintf(" >> plugin.mysql: failed, ensure the sscanf plugin is loaded first.\n");
+		logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
+		return false;
+	}
+}
 

--- a/src/sscanf.cpp
+++ b/src/sscanf.cpp
@@ -1,0 +1,120 @@
+#ifdef _WIN32
+        #define WIN32_LEAN_AND_MEAN
+        #define VC_EXTRALEAN
+        #include <Windows.h>
+        #include <psapi.h>
+#else
+        #include <dlfcn.h>
+        #include <cstring>
+#endif
+
+#include "sscanf.hpp"
+#include "sdk.hpp"
+
+sscanf_t PawnSScanf;
+extern logprintf_t logprintf;
+
+#ifdef _WIN32
+	bool FindSscanf()
+	{
+		// Find if sscanf is already loaded:
+		logprintf(" >> plugin.mysql: finding sscanf...");
+		HANDLE server = GetCurrentProcess();
+		HMODULE hMods[1024];
+		DWORD cbNeeded;
+		HMODULE dll = 0;
+		if (EnumProcessModules(server, hMods, sizeof(hMods), &cbNeeded))
+		{
+			for (unsigned int i = 0; i < (cbNeeded / sizeof(HMODULE)); i++)
+			{
+				TCHAR szModName[MAX_PATH];
+				if (GetModuleFileNameEx(server, hMods[i], szModName, sizeof(szModName) / sizeof(TCHAR)))
+				{
+					int len = strlen(szModName);
+					if (len >= 11 && strcmp("\\sscanf.DLL", szModName + len - 11) == 0)
+					{
+						dll = hMods[i];
+						break;
+					}
+				}
+			}
+		}
+
+		if (dll)
+		{
+			PawnSScanf = (sscanf_t)GetProcAddress(dll, "PawnSScanf");
+			if (PawnSScanf)
+			{
+				logprintf(" >> plugin.mysql: succeeded: %p.\n", PawnSScanf);
+				return true;
+			}
+			else
+			{
+				logprintf(" >> plugin.mysql: failed, ensure the plugin version is at least 2.10.3.\n");
+				logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
+				return false;
+			}
+		}
+		else
+		{
+			logprintf(" >> plugin.mysql: failed, ensure the sscanf plugin is loaded first.\n");
+			logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
+			return false;
+		}
+	}
+#else
+	struct lmap
+	{
+		void
+			* base_address;
+		char
+			* path;
+		void
+			* unk_1;
+		struct lmap
+			* next,
+			* prev;
+	};
+
+	bool FindSscanf()
+	{
+		// Find if sscanf is already loaded:
+		logprintf(" >> plugin.mysql: finding sscanf...");
+		struct lmap
+			* pl = (struct lmap *)dlopen(NULL, RTLD_NOW),
+			* dll = 0;
+
+		while (pl)
+		{
+			if (strcmp("plugins/sscanf.so", pl->path) == 0)
+			{
+				dll = pl;
+				break;
+			}
+			pl = pl->next;
+		}
+
+		if (dll)
+		{
+			*(void **)(&PawnSScanf) = dlsym(dll, "PawnSScanf");
+			if (PawnSScanf)
+			{
+				logprintf(" >> plugin.mysql: succeeded: %p.\n", PawnSScanf);
+				return true;
+			}
+			else
+			{
+				logprintf(" >> plugin.mysql: failed, ensure the plugin version is at least 2.10.3.\n");
+				logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
+				return false;
+			}
+		}
+		else
+		{
+			logprintf(" >> plugin.mysql: failed, ensure the sscanf plugin is loaded first.\n");
+			logprintf(" >> plugin.mysql: function 'cache_get_sscanf' disabled.\n");
+			return false;
+		}
+	}
+#endif
+

--- a/src/sscanf.hpp
+++ b/src/sscanf.hpp
@@ -1,0 +1,11 @@
+#if defined _WIN32 || defined __CYGWIN__
+	#define PAWN_NATIVE_API __cdecl
+#elif defined __linux__ || defined __APPLE__
+	#define PAWN_NATIVE_API __attribute__((cdecl))
+#endif
+
+typedef cell (PAWN_NATIVE_API *sscanf_t)(AMX * amx, char * string, char * format, cell * params, int paramCount, char * file, int line);
+extern sscanf_t PawnSScanf;
+
+bool FindSscanf();
+


### PR DESCRIPTION
I'm making this PR now as a work tracking PR (because hacktoberfest; if you could add the tag, that would be awesome).  I've not tested most of it yet because I can't actually build the plugin (#239), but I know the sscanf lookup and RPC works thanks to other testing (Y-Less/micro).  This adds a new function:

```pawn
native cache_get_native(cache, row, const format[], {Float, _}:...);
```

This is basically a wrapper around sscanf that passes the row data directly in and allows you to parse it with an sscanf-compatible specifier string.  It actually looks for and uses the sscanf plugin (sscanf needs to come first), so there's very little overhead in the code, and if you don't want it just don't include both plugins.