### PR TITLE
Bad finding comment characters in the line

### DIFF
--- a/src/CHandle.cpp
+++ b/src/CHandle.cpp
@@ -379,7 +379,7 @@ Handle_t CHandleManager::CreateFromFile(string file_path, CError<CHandle> &error
 
 		//erase comment from line
 		size_t comment_pos = line.find_first_of("#;");
-		if (comment_pos != string::npos)
+		if (comment_pos != string::npos && comment_pos == 0)
 			line.erase(comment_pos);
 
 		if (line.empty())


### PR DESCRIPTION
Hi. I have a problem when using function `mysql_connect_file` and file where i store data to connect to database.
The contents of this file:
```
hostname = localhost
username = root
database = some_database
password = hz@WTNFHIxI7~{VAMx3*}raAs8#~DFbE
```

The plugin searches the file for symbols '#' or ';' in **any position** of the line, but according to the INI-file parsing rules (https://en.wikipedia.org/wiki/INI_file#Comments), a comment is a line in which the comment character is **at the beginning of the line**. Due to this plugin error, it is impossible to use the `mysql_connect_file` function if the password contains one of these special characters ('#' or ';'), and I am forced to use `mysql_connect`.